### PR TITLE
Load from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,19 @@
 This ontology is describing Perovskite solar cells.
 
 ## Workflow
+
 Each ontology entry is an issue with the tag *ontology entry*. All discussions regarding the entries can be done inside the issue.
+
+## Inspect the ontology directly (locally) - *Try before buying*
+
+One can inspect the ontology locally without downloading this repository in any way.
+
+To do this, ensure that you have Protégé (or a similar ontology explorer) and have it set up in a proper way to inspect EMMO ontologies.
+Then, open the special Turtle file at this location: `https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/development/domain_photovoltaics_github.ttl`
+
+The exact steps needed to do this in Protégé are the following:
+
+1. Open Protégé.
+1. Go to "File -> Open from URL...".
+1. In the "URI" text box, enter the URL written above (`https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/development/domain_photovoltaics_github.ttl`).
+1. Press "OK".

--- a/domain_photovoltaics_github.ttl
+++ b/domain_photovoltaics_github.ttl
@@ -12,7 +12,7 @@
 @base <http://https://onto.onto-ns.com/domain-photovoltaics> .
 
 <http://onto.onto-ns.com/domain-photovoltaics> rdf:type owl:Ontology ;
-                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/domain_photovoltaics.ttl> ;
+                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/domain_photovoltaics_github.ttl> ;
                                                owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/photovoltaics.ttl> ;
                                                dcterms:abstract """A photovoltaics domain ontology based on EMMO.
 

--- a/domain_photovoltaics_github.ttl
+++ b/domain_photovoltaics_github.ttl
@@ -12,8 +12,8 @@
 @base <http://https://onto.onto-ns.com/domain-photovoltaics> .
 
 <http://onto.onto-ns.com/domain-photovoltaics> rdf:type owl:Ontology ;
-                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/main/domain_photovoltaics.ttl> ;
-                                               owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/main/photovoltaics.ttl> ;
+                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/domain_photovoltaics.ttl> ;
+                                               owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/photovoltaics.ttl> ;
                                                dcterms:abstract """A photovoltaics domain ontology based on EMMO.
 
 This file is intended to be empty and merely collecting the other ontologies.

--- a/domain_photovoltaics_github.ttl
+++ b/domain_photovoltaics_github.ttl
@@ -12,8 +12,8 @@
 @base <http://https://onto.onto-ns.com/domain-photovoltaics> .
 
 <http://onto.onto-ns.com/domain-photovoltaics> rdf:type owl:Ontology ;
-                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/domain_photovoltaics_github.ttl> ;
-                                               owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/photovoltaics.ttl> ;
+                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/development/domain_photovoltaics_github.ttl> ;
+                                               owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/development/photovoltaics.ttl> ;
                                                dcterms:abstract """A photovoltaics domain ontology based on EMMO.
 
 This file is intended to be empty and merely collecting the other ontologies.

--- a/domain_photovoltaics_github.ttl
+++ b/domain_photovoltaics_github.ttl
@@ -1,0 +1,42 @@
+@prefix : <http://onto.onto-ns.com/domain-photovoltaics#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix emmo: <http://emmo.info/emmo#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix annotations: <http://emmo.info/emmo/top/annotations#> .
+@prefix electrochemistry: <https://big-map.github.io/BattINFO/ontology/electrochemistry#> .
+@base <http://https://onto.onto-ns.com/domain-photovoltaics> .
+
+<http://onto.onto-ns.com/domain-photovoltaics> rdf:type owl:Ontology ;
+                                               owl:versionIRI <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/main/domain_photovoltaics.ttl> ;
+                                               owl:imports <https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/main/photovoltaics.ttl> ;
+                                               dcterms:abstract """A photovoltaics domain ontology based on EMMO.
+
+This file is intended to be empty and merely collecting the other ontologies.
+
+Released under the Creative Commons license Attribution 4.0 International (CC BY 4.0)."""@en ;
+                                                        dcterms:contributor "SINTEF, NO"@en ;
+                                                        dcterms:creator "Casper Welzel Andersen"@en ,
+                                                                        "Simon Clark"@en ;
+                                                        dcterms:license "https://creativecommons.org/licenses/by/4.0/legalcode" ;
+                                                        dcterms:title "EMMO Domain Ontology for Photovoltaics"@en ;
+                                                        rdfs:comment """Contacts:
+Casper Welzel Andersen
+SINTEF Industry
+email: casper.w.andersen@sintef.no"""@en ;
+                                                        owl:versionInfo "0.0.1" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://purl.org/dc/terms/abstract
+dcterms:abstract rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+dcterms:license rdf:type owl:AnnotationProperty .


### PR DESCRIPTION
Closes #19 

This introduces a Turtle file that can be referenced in Protégé to load the ontology directly from GitHub - no `git clone`-ing or similar needed.
It's important to understand that any changes will not be contributable, however. This will be - for all intents and purposes - a read-only way of checking out what is in the ontology.

To test this out, do the following:

1. Open Protégé.
2. Go to "File -> Open from URL...".
3. In the "URI" text box, enter the following: `https://raw.githubusercontent.com/emmo-repo/domain-photovoltaics/load_from_gh/domain_photovoltaics_github.ttl` and press "OK".

Furthermore, this will _only_ work while this PR exists.
Immediately prior to merging it, it should be changed to point to another branch.
Which branch should it then point to? `main` or some other branch?